### PR TITLE
doc: add resume intent protocol and contracts

### DIFF
--- a/doc/contracts/client/behaviour.md
+++ b/doc/contracts/client/behaviour.md
@@ -20,6 +20,8 @@ stateDiagram-v2
     RECONNECTING --> CONNECTED : dial success <br> (maxRetries not exhausted)
     RECONNECTING --> CLOSED : maxRetries exhausted
     RECONNECTING --> CLOSED : close()
+    RECONNECTING --> SESSION_EXPIRED : HTTP 410 or WS close 4100
+    SESSION_EXPIRED --> CLOSED : onSessionExpired fires
     CLOSED --> [*]
 ```
 
@@ -27,6 +29,10 @@ States are conceptual; implementations need not expose them as an enum.
 
 Note: `INIT → [*]` (connect failure) is a terminal path — the client object is
 never created, no callbacks fire, and `autoReconnect` has no effect.
+
+Note: `SESSION_EXPIRED` is a transient state — the client transitions to
+`CLOSED` immediately after `onSessionExpired` fires. The application layer
+decides whether to create a new connection.
 
 ---
 
@@ -53,12 +59,21 @@ never created, no callbacks fire, and `autoReconnect` has no effect.
 - Does **not** fire on the initial connection (only after a transport drop + successful reconnect).
 - Must fire before any `onMessage` from the new transport.
 
+### `onSessionExpired()`
+
+- Fires when a reconnect attempt receives **HTTP 410 Gone** or **WS close code 4100** (`CloseSessionExpired`) from the server.
+- Indicates the server session no longer exists: the resume window has expired or the server has restarted. Buffered messages from the previous session are lost.
+- The auto-reconnect loop **stops immediately** — the SDK does not retry.
+- Fires **before** `onDisconnect`.
+- The application layer decides the next step: establish a new connection, show UI, or exit.
+
 ### `onDisconnect(err)`
 
 - Fires **exactly once** per Client lifetime, when the client reaches `CLOSED`.
 - `err` is `nil`/`null` for a clean close (user called `close()`).
 - `err` is `RetriesExhaustedError` when max retries are exhausted.
 - `err` is `ConnectionLostError` when the server drops and auto-reconnect is off.
+- `err` is `SessionExpiredError` when the server session has expired (after `onSessionExpired` fires).
 - Must be the **last** callback to fire — no `onMessage` or `onTransportDrop` after this.
 
 ---
@@ -85,10 +100,12 @@ When `autoReconnect` is enabled:
 
 1. On transport drop → fire `onTransportDrop(err)`.
 2. Wait `delay = min(baseDelay × 2^attempt, maxDelay) × jitter(0.5..1.0)` (equal jitter).
-3. Attempt to dial.
-4. If successful → fire `onTransportRestore()` → go to `CONNECTED`; pending send-queue is preserved.
-5. If failed → increment `attempt`; if `attempt >= maxRetries > 0` → go to step 6; else go to step 2.
-6. Fire `onDisconnect(RetriesExhaustedError)` → `CLOSED`.
+3. Attempt to dial with `?resume=true` appended to the URL (reconnect only, not the initial connection).
+4. If HTTP 410 or WS close 4100 → go to step 7.
+5. If successful → fire `onTransportRestore()` → go to `CONNECTED`; pending send-queue is preserved.
+6. If failed → increment `attempt`; if `attempt >= maxRetries > 0` → go to step 8; else go to step 2.
+7. Fire `onSessionExpired()` → fire `onDisconnect(SessionExpiredError)` → `CLOSED`. Stop.
+8. Fire `onDisconnect(RetriesExhaustedError)` → `CLOSED`.
 
 When `autoReconnect` is disabled:
 
@@ -194,3 +211,5 @@ Every client lib must pass these behavioural tests against a live `wspulse/serve
 | 7   | Heartbeat: server closes after no Pong (simulated)                                    | Client reconnects (if auto-reconnect on)                       |
 | 8   | Concurrent `send()` from multiple threads/goroutines/tasks                            | No data race; all frames delivered in order per sender         |
 | 9   | `onDisconnect` + transport drop race (close() called simultaneously with server drop) | `onDisconnect` fires exactly once                              |
+| 10  | Session expired: server drops; resume window expires; client reconnects with `?resume=true` | `onSessionExpired` fires; `onDisconnect(SessionExpiredError)` fires; auto-reconnect stops |
+| 11  | Session expired: `onSessionExpired` fires, application creates a new connection | New `connect()` succeeds; new Client operates independently    |

--- a/doc/contracts/client/interface.md
+++ b/doc/contracts/client/interface.md
@@ -69,6 +69,7 @@ Every implementation must support these options:
 | `onDisconnect`    | `(error\|null) → void`              | no-op       | Called on permanent disconnect. `null`/`nil` = clean close. See behaviour doc for full semantics.                                                                                                              |
 | `onTransportDrop`    | `(error) → void`                    | no-op       | Called each time the underlying transport drops (before any reconnect).                                                                                                                                        |
 | `onTransportRestore` | `() → void`                         | no-op       | Called after a successful reconnect when the new transport is ready and pumps are running. Does not fire on the initial connection.                                                                             |
+| `onSessionExpired`   | `() → void`                         | no-op       | Called when a reconnect attempt discovers the server session no longer exists (HTTP 410 or WS close 4000). Auto-reconnect stops. The application layer decides whether to establish a new connection.           |
 | `autoReconnect`   | `(maxRetries, baseDelay, maxDelay)` | disabled    | Enable exponential backoff reconnect. `maxRetries = 0` means unlimited.                                                                                                                                        |
 | `heartbeat`       | `(pingPeriod, pongWait)`            | 20 s / 60 s | Client-side Ping/Pong interval. The client sends Ping every `pingPeriod` and closes the socket if no Pong arrives within `pongWait`. Browser clients: no-op (browser handles Ping/Pong at the protocol level). |
 | `writeWait`       | duration                            | 10 s        | Deadline for a single write operation.                                                                                                                                                                         |
@@ -138,6 +139,7 @@ Each language maps these sentinel concepts to its own error type. The names belo
 | `SendBufferFullError`   | `send()` called when the internal send buffer is full.                    |
 | `RetriesExhaustedError` | Passed to `onDisconnect` when max reconnect retries are exhausted.        |
 | `ConnectionLostError`   | Passed to `onDisconnect` when the server drops and auto-reconnect is off. |
+| `SessionExpiredError`   | Passed to `onDisconnect` when the server session has expired (HTTP 410 or WS close 4100). Fires after `onSessionExpired`. |
 
 ---
 
@@ -156,3 +158,4 @@ Each language maps these sentinel concepts to its own error type. The names belo
 | SendBufferFull   | `ErrSendBufferFull` (from core)        | `SendBufferFullError`              | `SendBufferFullException`                | `WspulseError.sendBufferFull`            | `SendBufferFullError`                           |
 | RetriesExhausted | `ErrRetriesExhausted`                  | `RetriesExhaustedError`            | `RetriesExhaustedException`              | `WspulseError.retriesExhausted`          | `RetriesExhaustedError`                         |
 | ConnectionLost   | `ErrConnectionLost`                    | `ConnectionLostError`              | `ConnectionLostException`                | `WspulseError.connectionLost`            | `ConnectionLostError`                           |
+| SessionExpired   | `ErrSessionExpired`                    | `SessionExpiredError`              | `SessionExpiredException`                | `WspulseError.sessionExpired`            | `SessionExpiredError`                           |

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -147,6 +147,70 @@ never dropped.
 
 ---
 
+## Resume Intent
+
+When a client reconnects after a transport failure, it MUST include
+`resume=true` as a query parameter in the WebSocket upgrade URL:
+
+```
+ws://host/ws?token=abc&resume=true
+```
+
+This signals to the server that the client intends to resume a previously
+suspended session. The `resume` parameter is a boolean flag; the
+`connectionID` is conveyed separately via `ConnectFunc` (application-layer
+responsibility, not part of this protocol).
+
+### Server behaviour
+
+The server evaluates the `resume` parameter in `ServeHTTP`, **before** the
+WebSocket upgrade:
+
+| Condition | Action |
+| --- | --- |
+| `resume=true`, session exists (any state) | Upgrade, resume session (existing behaviour) |
+| `resume=true`, session does not exist | **HTTP 410 Gone** — do not upgrade |
+| `resume` absent or false | Upgrade, create new session (existing behaviour) |
+
+**HTTP 410 Gone** in the wspulse context means: the client requested session
+resumption but the session no longer exists. The grace window has expired or
+the server has restarted. Buffered messages from the previous session are
+lost. The client MUST NOT automatically retry with `resume=true`.
+
+### Race condition
+
+In rare cases the HTTP pre-check may pass (session exists) but the session is
+destroyed by the grace timer before the hub processes the registration. When
+this happens, the server sends a WebSocket close frame with code **4100**
+(`CloseSessionExpired`) and does not create a new session. The client handles
+this identically to HTTP 410.
+
+### Close code 4100 — CloseSessionExpired
+
+| Code | Name | Meaning |
+| --- | --- | --- |
+| 4100 | `CloseSessionExpired` | Session resumption requested but the session no longer exists. Sent only in the upgrade-then-discover race case described above. |
+
+### Metrics
+
+The server emits `ResumeAttempt(roomID, connectionID, false)` for every
+rejected resume — whether via HTTP 410 or close code 4100.
+
+### Security
+
+The `resume` parameter is an intent signal only. Session ownership is
+verified by `ConnectFunc`, which authenticates the HTTP request and returns
+the `connectionID`. **`ConnectFunc` MUST ensure that a reconnecting client is
+the same identity that originally created the session.** Failure to do so
+allows session hijacking: an attacker who passes `ConnectFunc` with a known
+`connectionID` could resume another user's session and receive their buffered
+messages.
+
+wspulse does not enforce session ownership at the protocol layer. This is an
+application-layer responsibility, analogous to HTTP session token security.
+
+---
+
 ## Versioning
 
 This protocol document is versioned alongside the wspulse module. Breaking


### PR DESCRIPTION
## Summary

- `doc/protocol.md` — new Resume Intent section: `?resume=true` query parameter semantics, HTTP 410 Gone definition, WS close 4100 (`CloseSessionExpired`) definition, security note on ConnectFunc responsibility
- `doc/contracts/client/interface.md` — add `onSessionExpired` callback interface definition
- `doc/contracts/client/behaviour.md` — add resume intent behaviour: reconnect with `?resume=true`, HTTP 410 / WS 4100 handling, stop auto-reconnect, callback trigger timing

## Test plan

- [x] Protocol spec reviewed for consistency with server implementation
- [x] Client contracts align with planned SDK behaviour (Phase 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)