### PR TITLE
chore: adjust race count by branch context

### DIFF
--- a/.github/workflows/go-check.yml
+++ b/.github/workflows/go-check.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
-      TEST_COUNT: ${{ (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.base_ref == 'main')) && '5' || (github.ref == 'refs/heads/develop' || (github.event_name == 'pull_request' && github.base_ref == 'develop')) && '3' || '1' }}
+      TEST_COUNT: ${{ (github.ref == 'refs/heads/main' || github.base_ref == 'main') && '5' || (github.ref == 'refs/heads/develop' || github.base_ref == 'develop') && '3' || '1' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/go-integration.yml
+++ b/.github/workflows/go-integration.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
-      TEST_COUNT: ${{ (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.base_ref == 'main')) && '5' || (github.ref == 'refs/heads/develop' || (github.event_name == 'pull_request' && github.base_ref == 'develop')) && '3' || '1' }}
+      TEST_COUNT: ${{ (github.ref == 'refs/heads/main' || github.base_ref == 'main') && '5' || (github.ref == 'refs/heads/develop' || github.base_ref == 'develop') && '3' || '1' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- main-related (push to main, PR to main): `-race -count=5`
- develop-related (push to develop, PR to develop): `-race -count=3`
- Feature branches: `-race -count=1`

Applied to both `go-check.yml` and `go-integration.yml` reusable workflows.