### PR TITLE
chore: raise CI race-detect count + add stress job

### DIFF
--- a/.github/workflows/go-check.yml
+++ b/.github/workflows/go-check.yml
@@ -6,9 +6,10 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     env:
-      TEST_COUNT: ${{ (github.ref == 'refs/heads/main' || github.base_ref == 'main') && '5' || (github.ref == 'refs/heads/develop' || github.base_ref == 'develop') && '3' || '1' }}
+      TEST_COUNT: ${{ (github.ref == 'refs/heads/main' || github.base_ref == 'main') && '100' || (github.ref == 'refs/heads/develop' || github.base_ref == 'develop') && '50' || '10' }}
+      TEST_TIMEOUT: ${{ (github.ref == 'refs/heads/main' || github.base_ref == 'main') && '300s' || (github.ref == 'refs/heads/develop' || github.base_ref == 'develop') && '180s' || '120s' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -28,4 +29,4 @@ jobs:
           version: v2.11.2
 
       - name: Run tests
-        run: go test -v -race -count=${{ env.TEST_COUNT }} -timeout 120s ./...
+        run: go test -v -race -count=${{ env.TEST_COUNT }} -timeout ${{ env.TEST_TIMEOUT }} ./...

--- a/.github/workflows/go-integration.yml
+++ b/.github/workflows/go-integration.yml
@@ -6,9 +6,10 @@ on:
 jobs:
   integration:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     env:
-      TEST_COUNT: ${{ (github.ref == 'refs/heads/main' || github.base_ref == 'main') && '5' || (github.ref == 'refs/heads/develop' || github.base_ref == 'develop') && '3' || '1' }}
+      TEST_COUNT: ${{ (github.ref == 'refs/heads/main' || github.base_ref == 'main') && '100' || (github.ref == 'refs/heads/develop' || github.base_ref == 'develop') && '50' || '10' }}
+      TEST_TIMEOUT: ${{ (github.ref == 'refs/heads/main' || github.base_ref == 'main') && '300s' || (github.ref == 'refs/heads/develop' || github.base_ref == 'develop') && '180s' || '120s' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -23,4 +24,4 @@ jobs:
         run: go mod download
 
       - name: Run integration tests
-        run: go test -v -race -count=${{ env.TEST_COUNT }} -tags integration -timeout 120s ./...
+        run: go test -v -race -count=${{ env.TEST_COUNT }} -tags integration -timeout ${{ env.TEST_TIMEOUT }} ./...

--- a/.github/workflows/go-stress.yml
+++ b/.github/workflows/go-stress.yml
@@ -1,0 +1,63 @@
+name: Go Stress (reusable)
+
+on:
+  workflow_call:
+
+jobs:
+  stress:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Download modules
+        run: go mod download
+
+      - name: Run stress tests
+        run: go test -race -count=500 -timeout 600s ./...
+
+      - name: Report failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const today = new Date().toISOString().split('T')[0];
+
+            // Search for existing open issue with race-condition label
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              labels: 'race-condition',
+              state: 'open',
+              per_page: 1,
+            });
+
+            if (issues.length > 0) {
+              // Append comment to existing issue
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issues[0].number,
+                body: `Race condition detected again on ${today}.\n\nFailed run: ${runUrl}`,
+              });
+              core.info(`Commented on existing issue #${issues[0].number}`);
+            } else {
+              // Create new issue
+              await github.rest.issues.create({
+                owner,
+                repo,
+                title: `Race condition detected — ${today}`,
+                body: `Weekly stress test (\`-race -count=500\`) failed.\n\nFailed run: ${runUrl}\n\nThis issue was automatically created by the stress test workflow.`,
+                labels: ['bug', 'race-condition'],
+              });
+              core.info('Created new issue');
+            }


### PR DESCRIPTION
## Summary

Raise CI merge gate `-race -count` from 5/3/1 to 100/50/10 (main/develop/feature) with tiered timeouts, and add a weekly stress test workflow (`count=500`) with automatic issue reporting. Part of wspulse/.github#26.

## Changes

- `go-check.yml`: `TEST_COUNT` raised to 100/50/10, added `TEST_TIMEOUT` (300s/180s/120s), `timeout-minutes` 10 to 15
- `go-integration.yml`: same changes as `go-check.yml`
- `go-stress.yml` (new): reusable weekly stress test — `count=500`, `timeout=600s`, no `-v`; on failure auto-creates or appends to a GitHub issue with `race-condition` label

## Checklist

### Required

- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [ ] Workflow changes: tested on a feature branch before merging
