### PR TITLE
doc: remove client-side ping from contracts

### DIFF
--- a/doc/contracts/client/behaviour.md
+++ b/doc/contracts/client/behaviour.md
@@ -276,30 +276,14 @@ indistinguishable from any other transport drop from the caller's perspective.
 
 ## Heartbeat
 
-wspulse uses a **dual heartbeat** model: both the server and the client independently send WebSocket **Ping** control frames and monitor **Pong** replies to detect dead connections.
-
-### Server-side heartbeat
+wspulse uses a **server-only heartbeat** model. The server sends WebSocket **Ping** control frames and monitors **Pong** replies to detect dead connections. Clients do not send their own Ping frames.
 
 - The server sends Ping every `pingPeriod` (default **10 s**).
 - If no Pong is received within `pongWait` (default **30 s**), the server closes the connection.
 - Clients auto-reply Pong at the protocol layer (handled by gorilla/websocket, browser engines, and other standard WebSocket libraries).
+- When the server closes a dead connection, the client detects it via a read error, which triggers a transport drop (and reconnect if enabled).
 
-### Client-side heartbeat
-
-- Native clients (Go, Node.js) **also** send their own Ping every `pingPeriod` (default **20 s**).
-- If no Pong is received within `pongWait` (default **60 s**), the client closes the socket, triggering a transport drop (and reconnect if enabled).
-- The server auto-replies Pong at the protocol layer (gorilla default `PingHandler`).
-- **Browser clients** cannot send Ping frames — the browser WebSocket API provides no programmatic access to Ping/Pong control frames. In browser environments the client-side heartbeat is a **no-op**; liveness detection relies entirely on the server-side heartbeat.
-
-### Why dual heartbeat?
-
-- **Independent fault detection** — each side detects the other's failure on its own schedule without a one-directional dependency.
-- **Staggered defaults** — the server uses a tight interval (10 s / 30 s) for fast resource reclamation; clients use a lenient interval (20 s / 60 s) suited for mobile and spotty networks.
-- **NAT keepalive** — client-initiated Ping keeps NAT/firewall state alive. Some corporate proxies only track client-originated traffic.
-
-### Configurability
-
-Both `pingPeriod` and `pongWait` are fully configurable on each side. Developers should adjust values to match their network environment and resource constraints. The constraint `pingPeriod < pongWait` must always hold.
+Dead-connection detection latency is `server.pingInterval + server.writeTimeout`, controlled by the server operator. This is the standard pattern used by Phoenix, socket.io, ActionCable, Ably, Pusher, and NATS.
 
 ---
 
@@ -329,7 +313,7 @@ Rules:
 
 1. **Enabled by default** — the logger must produce output without any user configuration. Users may replace or disable it via options.
 2. **Minimum log points** — the following events must be logged:
-   - `warn`: decode failure (frame dropped), write failure, pong timeout, retries exhausted.
+   - `warn`: decode failure (frame dropped), write failure, retries exhausted.
    - `info`: connected, reconnected, closing, transport dropped.
    - `debug`: reconnect attempt with delay.
 3. **Message prefix** — all log messages must start with `wspulse/client:`.
@@ -344,12 +328,11 @@ Every client lib must pass these behavioural tests against a live `wspulse/serve
 | --- | ------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
 | 1   | Connect, send frame, receive echo, `close()` cleanly                                  | `onTransportDrop(nil)` → `onDisconnect(nil)`; `done` resolves                    |
 | 2   | Server drops connection (auto-reconnect off)                                          | `onTransportDrop` → `onDisconnect(ConnectionLostError)`                          |
-| 3   | Server drops; client reconnects within maxRetries                                     | `onTransportDrop` → `onReconnect(0)` → `onMessage` works again                   |
+| 3   | Server drops; client reconnects within maxRetries                                     | `onTransportDrop` → `onTransportRestore()` → `onMessage` works again              |
 | 4   | Server drops repeatedly; max retries exhausted                                        | `onDisconnect(RetriesExhaustedError)` fires exactly once                         |
 | 5   | `close()` called during reconnect loop                                                | Loop stops; `onDisconnect(nil)` fires; no further callbacks                      |
 | 6   | `send()` after `close()`                                                              | Raises / returns `ConnectionClosedError`                                         |
-| 7   | Heartbeat: server closes after no Pong (simulated)                                    | Client reconnects (if auto-reconnect on)                                         |
-| 8   | Concurrent `send()` from multiple threads/goroutines/tasks                            | No data race; all frames delivered in order per sender                           |
-| 9   | `onDisconnect` + transport drop race (close() called simultaneously with server drop) | `onTransportDrop` fires exactly once; `onDisconnect` fires exactly once          |
-| 10  | `close()` called during in-flight `connect()` dial                                    | Zero callbacks fire; `connect()` throws `ConnectionClosedError`; `done` resolves |
-| 11  | Write timeout: socket write stalls beyond `writeWait`                                 | `onTransportDrop(err)` fires with non-nil error; reconnects if auto-reconnect on |
+| 7   | Concurrent `send()` from multiple threads/goroutines/tasks                            | No data race; all frames delivered in order per sender                           |
+| 8   | `onDisconnect` + transport drop race (close() called simultaneously with server drop) | `onTransportDrop` fires exactly once; `onDisconnect` fires exactly once          |
+| 9   | `close()` called during in-flight `connect()` dial                                    | Zero callbacks fire; `connect()` throws `ConnectionClosedError`; `done` resolves |
+| 10  | Write timeout: socket write stalls beyond `writeWait`                                 | `onTransportDrop(err)` fires with non-nil error; reconnects if auto-reconnect on |

--- a/doc/contracts/client/behaviour.md
+++ b/doc/contracts/client/behaviour.md
@@ -280,7 +280,7 @@ wspulse uses a **server-only heartbeat** model. The server sends WebSocket **Pin
 
 - The server sends Ping every `pingInterval` (default **20 s**).
 - If no Pong is received within `writeTimeout` (default **10 s**), the server closes the connection.
-- Clients auto-reply Pong at the protocol layer (handled by gorilla/websocket, browser engines, and other standard WebSocket libraries).
+- Clients auto-reply Pong at the protocol layer (handled by standard WebSocket libraries and browser engines).
 - When the server closes a dead connection, the client detects it via a read error, which triggers a transport drop (and reconnect if enabled).
 
 Dead-connection detection latency is `server.pingInterval + server.writeTimeout`, controlled by the server operator. This is the standard pattern used by Phoenix, socket.io, ActionCable, Ably, Pusher, and NATS.

--- a/doc/contracts/client/behaviour.md
+++ b/doc/contracts/client/behaviour.md
@@ -278,8 +278,8 @@ indistinguishable from any other transport drop from the caller's perspective.
 
 wspulse uses a **server-only heartbeat** model. The server sends WebSocket **Ping** control frames and monitors **Pong** replies to detect dead connections. Clients do not send their own Ping frames.
 
-- The server sends Ping every `pingPeriod` (default **10 s**).
-- If no Pong is received within `pongWait` (default **30 s**), the server closes the connection.
+- The server sends Ping every `pingInterval` (default **20 s**).
+- If no Pong is received within `writeTimeout` (default **10 s**), the server closes the connection.
 - Clients auto-reply Pong at the protocol layer (handled by gorilla/websocket, browser engines, and other standard WebSocket libraries).
 - When the server closes a dead connection, the client detects it via a read error, which triggers a transport drop (and reconnect if enabled).
 

--- a/doc/contracts/client/interface.md
+++ b/doc/contracts/client/interface.md
@@ -73,7 +73,6 @@ Every implementation must support these options:
 | `onTransportDrop`    | `(error) → void`                    | no-op       | Called each time the underlying transport drops (before any reconnect).                                                                                                                                        |
 | `onTransportRestore` | `() → void`                         | no-op       | Called after a successful reconnect when the new transport is ready and pumps are running. Does not fire on the initial connection.                                                                             |
 | `autoReconnect`   | `(maxRetries, baseDelay, maxDelay)` | disabled    | Enable exponential backoff reconnect. `maxRetries = 0` means unlimited.                                                                                                                                        |
-| `heartbeat`       | `(pingPeriod, pongWait)`            | 20 s / 60 s | Client-side Ping/Pong interval. The client sends Ping every `pingPeriod` and closes the socket if no Pong arrives within `pongWait`. Browser clients: no-op (browser handles Ping/Pong at the protocol level). |
 | `writeWait`       | duration                            | 10 s        | Deadline for a single write operation.                                                                                                                                                                         |
 | `maxMessageSize`  | bytes (int)                         | 1 MiB       | Max inbound message size. Connection closed if exceeded.                                                                                                                                                       |
 | `sendBufferSize`  | frames (int)                        | 256         | Outbound send buffer capacity (number of frames). When full, `send()` returns `SendBufferFullError`. During reconnect, buffered frames are delivered after the new transport is established.                    |
@@ -96,19 +95,14 @@ All validation error messages must use the prefix `wspulse:` followed by a space
 | 2   | `maxMessageSize`           | `<= 64 MiB`                  | `wspulse: maxMessageSize exceeds maximum (64 MiB)`                            |
 | 3   | `writeWait`                | `> 0`                        | `wspulse: writeWait must be positive`                                         |
 | 4   | `writeWait`                | `<= 30 s`                    | `wspulse: writeWait exceeds maximum (30s)`                                    |
-| 5   | `heartbeat.pingPeriod`     | `> 0`                        | `wspulse: heartbeat.pingPeriod must be positive`                              |
-| 6   | `heartbeat.pingPeriod`     | `<= 1 m`                     | `wspulse: heartbeat.pingPeriod exceeds maximum (1m)`                          |
-| 7   | `heartbeat.pongWait`       | `> 0`                        | `wspulse: heartbeat.pongWait must be positive`                                |
-| 8   | `heartbeat.pongWait`       | `<= 2 m`                     | `wspulse: heartbeat.pongWait exceeds maximum (2m)`                            |
-| 9   | `heartbeat.pingPeriod`     | `< heartbeat.pongWait`       | `wspulse: heartbeat.pingPeriod must be strictly less than heartbeat.pongWait` |
-| 10  | `autoReconnect.maxRetries` | `>= 0`                       | `wspulse: autoReconnect.maxRetries must be non-negative`                      |
-| 11  | `autoReconnect.baseDelay`  | `> 0`                        | `wspulse: autoReconnect.baseDelay must be positive`                           |
-| 12  | `autoReconnect.baseDelay`  | `<= 1 m`                     | `wspulse: autoReconnect.baseDelay exceeds maximum (1m)`                       |
-| 13  | `autoReconnect.maxDelay`   | `>= autoReconnect.baseDelay` | `wspulse: autoReconnect.maxDelay must be >= autoReconnect.baseDelay`          |
-| 14  | `autoReconnect.maxDelay`   | `<= 5 m`                     | `wspulse: autoReconnect.maxDelay exceeds maximum (5m)`                        |
-| 15  | `autoReconnect.maxRetries` | `<= 32` (when `> 0`)         | `wspulse: autoReconnect.maxRetries exceeds maximum (32)`                      |
-| 16  | `sendBufferSize`           | `>= 1`                       | `wspulse: sendBufferSize must be at least 1`                                  |
-| 17  | `sendBufferSize`           | `<= 4096`                    | `wspulse: sendBufferSize exceeds maximum (4096)`                              |
+| 5   | `autoReconnect.maxRetries` | `>= 0`                       | `wspulse: autoReconnect.maxRetries must be non-negative`                      |
+| 6   | `autoReconnect.baseDelay`  | `> 0`                        | `wspulse: autoReconnect.baseDelay must be positive`                           |
+| 7   | `autoReconnect.baseDelay`  | `<= 1 m`                     | `wspulse: autoReconnect.baseDelay exceeds maximum (1m)`                       |
+| 8   | `autoReconnect.maxDelay`   | `>= autoReconnect.baseDelay` | `wspulse: autoReconnect.maxDelay must be >= autoReconnect.baseDelay`          |
+| 9   | `autoReconnect.maxDelay`   | `<= 5 m`                     | `wspulse: autoReconnect.maxDelay exceeds maximum (5m)`                        |
+| 10  | `autoReconnect.maxRetries` | `<= 32` (when `> 0`)         | `wspulse: autoReconnect.maxRetries exceeds maximum (32)`                      |
+| 11  | `sendBufferSize`           | `>= 1`                       | `wspulse: sendBufferSize must be at least 1`                                  |
+| 12  | `sendBufferSize`           | `<= 4096`                    | `wspulse: sendBufferSize exceeds maximum (4096)`                              |
 
 Notes:
 

--- a/doc/contracts/client/interface.md
+++ b/doc/contracts/client/interface.md
@@ -106,7 +106,7 @@ All validation error messages must use the prefix `wspulse:` followed by a space
 
 Notes:
 
-- **URL scheme handling**: `http://` is auto-converted to `ws://`, `https://` to `wss://`. Matching is case-insensitive per RFC 3986 (`HTTP://`, `Http://` are accepted). `ws://` and `wss://` are accepted as-is. Unsupported or missing schemes must be rejected immediately at setup time (panic, throw, or precondition failure per language convention) with a `wspulse:`-prefixed error message. Implementations where the underlying WebSocket library already provides a clear error for invalid schemes (Go gorilla, Node.js ws) may delegate this validation.
+- **URL scheme handling**: `http://` is auto-converted to `ws://`, `https://` to `wss://`. Matching is case-insensitive per RFC 3986 (`HTTP://`, `Http://` are accepted). `ws://` and `wss://` are accepted as-is. Unsupported or missing schemes must be rejected immediately at setup time (panic, throw, or precondition failure per language convention) with a `wspulse:`-prefixed error message. Implementations where the underlying WebSocket library already provides a clear error for invalid schemes (Go coder/websocket, Node.js ws) may delegate this validation.
 
 - `maxMessageSize = 0` means disabled (no size limit enforced).
 - `autoReconnect.maxRetries = 0` means unlimited retries.

--- a/doc/contracts/client/test-scenarios.md
+++ b/doc/contracts/client/test-scenarios.md
@@ -31,34 +31,32 @@ All client libraries test against the same Go binary located at [`testserver/`](
 | `?reject=1`       | Server returns HTTP 403 on upgrade (simulates auth failure)    |
 | `?room=<id>`      | Join a specific room                                           |
 | `?id=<id>`        | Register a session ID (required for `/kick`)                   |
-| `?ignore_pings=1` | Server suppresses Pong replies (for heartbeat timeout testing) |
 
 ---
 
 ## Scenario Matrix
 
-Every client must implement tests for the following 11 scenarios. Error type names are conceptual — use the language-appropriate mapping from `interface.md`.
+Every client must implement tests for the following 10 scenarios. Error type names are conceptual — use the language-appropriate mapping from `interface.md`.
 
-| #   | Scenario                                                            | Behaviour Reference                  | Query Params      | Notes                                   |
-| --- | ------------------------------------------------------------------- | ------------------------------------ | ----------------- | --------------------------------------- |
-| 1   | Connect → send → echo → close clean                                 | Lifecycle: INIT → CONNECTED → CLOSED | —                 | Basic happy-path                        |
-| 2   | Server drops → `onTransportDrop` + `onDisconnect` (no reconnect)    | `onTransportDrop`, `onDisconnect`    | —                 | autoReconnect disabled                  |
-| 3   | Auto-reconnect: server drops → reconnects within maxRetries         | Auto-Reconnect steps 1–4             | `?id=…`           | Use `/kick` to trigger drop             |
-| 4   | Max retries exhausted → `onDisconnect(RetriesExhaustedError)`       | Auto-Reconnect step 6                | `?id=…`           | Use `/shutdown` to make all dials fail  |
-| 5   | `close()` during reconnect → loop stops, `onDisconnect(nil)`        | `close()` Semantics                  | `?id=…`           | Call `close()` during reconnect backoff |
-| 6   | `send()` on closed client → `ConnectionClosedError`                 | `send()` Semantics                   | —                 |                                         |
-| 7   | Heartbeat pong timeout → `ConnectionLostError`                      | Heartbeat: client-side               | `?ignore_pings=1` | Short `pingPeriod`/`pongWait` for speed |
-| 8   | Concurrent sends: no data race or interleaving                      | `send()` Semantics: ordering         | —                 | See [Threading note](#threading-note)   |
-| 9   | Concurrent `close()` + transport drop → `onDisconnect` exactly once | `close()` Semantics: idempotent      | —                 |                                         |
-| 10  | `onTransportRestore` fires after successful reconnect               | `onTransportRestore`                 | `?id=…`           | Use `/kick` then reconnect              |
-| 11  | `onTransportRestore` does not fire on initial connect               | `onTransportRestore`                 | —                 |                                         |
+| #   | Scenario                                                            | Behaviour Reference                  | Query Params | Notes                                   |
+| --- | ------------------------------------------------------------------- | ------------------------------------ | ------------ | --------------------------------------- |
+| 1   | Connect → send → echo → close clean                                 | Lifecycle: INIT → CONNECTED → CLOSED | —            | Basic happy-path                        |
+| 2   | Server drops → `onTransportDrop` + `onDisconnect` (no reconnect)    | `onTransportDrop`, `onDisconnect`    | —            | autoReconnect disabled                  |
+| 3   | Auto-reconnect: server drops → reconnects within maxRetries         | Auto-Reconnect steps 1–4             | `?id=…`      | Use `/kick` to trigger drop             |
+| 4   | Max retries exhausted → `onDisconnect(RetriesExhaustedError)`       | Auto-Reconnect step 6                | `?id=…`      | Use `/shutdown` to make all dials fail  |
+| 5   | `close()` during reconnect → loop stops, `onDisconnect(nil)`        | `close()` Semantics                  | `?id=…`      | Call `close()` during reconnect backoff |
+| 6   | `send()` on closed client → `ConnectionClosedError`                 | `send()` Semantics                   | —            |                                         |
+| 7   | Concurrent sends: no data race or interleaving                      | `send()` Semantics: ordering         | —            | See [Threading note](#threading-note)   |
+| 8   | Concurrent `close()` + transport drop → `onDisconnect` exactly once | `close()` Semantics: idempotent      | —            |                                         |
+| 9   | `onTransportRestore` fires after successful reconnect               | `onTransportRestore`                 | `?id=…`      | Use `/kick` then reconnect              |
+| 10  | `onTransportRestore` does not fire on initial connect               | `onTransportRestore`                 | —            |                                         |
 
 ### Threading Note
 
-Scenario 8 verifies that concurrent `send()` calls do not cause data races or message interleaving.
+Scenario 7 verifies that concurrent `send()` calls do not cause data races or message interleaving.
 
 - **Multi-threaded runtimes** (Go, Kotlin, Swift): implement as a scenario matrix test — launch N goroutines/coroutines each sending M frames, verify all arrive intact and in per-sender order.
-- **Single-threaded runtimes** (JavaScript/TypeScript): mark scenario 8 as N/A in the scenario matrix. Instead, add an equivalent test in the Additional Tests section (e.g. fire N sends via `Promise.all`, verify ordering and completeness).
+- **Single-threaded runtimes** (JavaScript/TypeScript): mark scenario 7 as N/A in the scenario matrix. Instead, add an equivalent test in the Additional Tests section (e.g. fire N sends via `Promise.all`, verify ordering and completeness).
 
 The concurrent-send behaviour **must** be tested in every client; only the placement differs.
 
@@ -82,10 +80,10 @@ Beyond the scenario matrix, every client must include these tests:
 
 | Runtime model   | Scenario matrix | Additional tests | Total |
 | --------------- | --------------- | ---------------- | ----- |
-| Multi-threaded  | 11              | 5                | 16    |
-| Single-threaded | 10 (sc.8 = N/A) | 6 (+concurrent)  | 16    |
+| Multi-threaded  | 10              | 5                | 15    |
+| Single-threaded | 9 (sc.7 = N/A)  | 6 (+concurrent)  | 15    |
 
-All clients must reach a minimum of **16 integration tests**.
+All clients must reach a minimum of **15 integration tests**.
 
 ---
 

--- a/doc/contracts/client/test-scenarios.md
+++ b/doc/contracts/client/test-scenarios.md
@@ -13,7 +13,9 @@ For behavioural requirements see [`behaviour.md`](./behaviour.md).
 
 ## Shared Testserver
 
-All client libraries test against the same Go binary located at [`testserver/`](../../../testserver/). It runs a standard `wspulse/server` with control endpoints for test orchestration.
+> **Outdated** — the `testserver/` module has been removed. This section and the Testserver Lifecycle section below will be redesigned. The control API and query parameter contracts remain as reference for each SDK's embedded test infrastructure.
+
+All client libraries test against a wspulse/server instance with control endpoints for test orchestration.
 
 ### Control API
 
@@ -89,7 +91,9 @@ All clients must reach a minimum of **15 integration tests**.
 
 ## Testserver Lifecycle
 
-Each client library is responsible for starting/stopping the testserver during its test run. Common strategies:
+> **Outdated** — the `testserver/` module has been removed. This section will be redesigned.
+
+Each client library is responsible for starting/stopping the test server during its test run. Common strategies:
 
 - **Go**: `exec.Command` in `TestMain`.
 - **TypeScript**: vitest `globalSetup` / `globalTeardown`.

--- a/doc/contracts/server/behaviour.md
+++ b/doc/contracts/server/behaviour.md
@@ -119,11 +119,12 @@ The server uses RFC 6455 Ping/Pong control frames for liveness detection.
 | Parameter      | Default | Valid Range | Description                                                       |
 | -------------- | ------- | ----------- | ----------------------------------------------------------------- |
 | `pingInterval` | 20 s    | (writeTimeout, 1m] | Server sends a Ping every `pingInterval`.                    |
-| `writeTimeout` | 10 s    | (0, 30s]    | Deadline for a single write (including Ping). No Pong within this window = connection dead. |
+| `writeTimeout` | 10 s    | (0, 30s]    | Deadline for a single write operation, including the synchronous Ping/Pong round-trip. |
 
+- The server's `Ping(ctx)` is synchronous: it sends a Ping frame and blocks until the Pong reply arrives or the `writeTimeout` context expires. If the Pong does not arrive within `writeTimeout`, the connection is considered dead.
 - The constraint `pingInterval > writeTimeout` must always hold.
 - Clients auto-reply Pong at the WebSocket protocol layer (no application-level handling needed).
-- The server also auto-replies to client-initiated Pings (gorilla default `PingHandler`).
+- The server also auto-replies to client-initiated Pings (default ping handler).
 
 ---
 

--- a/doc/contracts/server/behaviour.md
+++ b/doc/contracts/server/behaviour.md
@@ -116,14 +116,14 @@ When a session is suspended (within the resume window), frames are buffered in a
 
 The server uses RFC 6455 Ping/Pong control frames for liveness detection.
 
-| Parameter    | Default | Valid Range       | Description                                                |
-| ------------ | ------- | ----------------- | ---------------------------------------------------------- |
-| `pingPeriod` | 10 s    | (0, 5m]           | Server sends a Ping every `pingPeriod`.                    |
-| `pongWait`   | 30 s    | (pingPeriod, 10m] | If no Pong arrives within `pongWait`, the connection dies. |
+| Parameter      | Default | Valid Range | Description                                                       |
+| -------------- | ------- | ----------- | ----------------------------------------------------------------- |
+| `pingInterval` | 20 s    | (writeTimeout, 1m] | Server sends a Ping every `pingInterval`.                    |
+| `writeTimeout` | 10 s    | (0, 30s]    | Deadline for a single write (including Ping). No Pong within this window = connection dead. |
 
+- The constraint `pingInterval > writeTimeout` must always hold.
 - Clients auto-reply Pong at the WebSocket protocol layer (no application-level handling needed).
 - The server also auto-replies to client-initiated Pings (gorilla default `PingHandler`).
-- The constraint `pingPeriod < pongWait` must always hold.
 
 ---
 

--- a/doc/contracts/server/interface.md
+++ b/doc/contracts/server/interface.md
@@ -123,8 +123,8 @@ All options are set via functional option builders. Invalid values panic at setu
 | `WithOnDisconnect(fn)`         | `func(Connection, error)`        | --             | --                    |
 | `WithOnTransportDrop(fn)`      | `func(Connection, error)`        | --             | --                    |
 | `WithOnTransportRestore(fn)`   | `func(Connection)`               | --             | --                    |
-| `WithHeartbeat(ping, pong)` | `(time.Duration, time.Duration)` | 10 s / 30 s    | (0, 5m] / (ping, 10m] |
-| `WithWriteWait(d)`          | `time.Duration`                  | 10 s           | (0, 30s]              |
+| `WithPingInterval(d)`       | `time.Duration`                  | 20 s           | (writeTimeout, 1m]    |
+| `WithWriteTimeout(d)`       | `time.Duration`                  | 10 s           | (0, 30s]              |
 | `WithMaxMessageSize(n)`     | `int64`                          | 512 B          | [1, 64 MiB]           |
 | `WithSendBufferSize(n)`     | `int`                            | 256 frames     | [1, 4096]             |
 | `WithResumeWindow(d)`       | `time.Duration`                  | 0 (disabled)   | [0, +∞)               |
@@ -155,30 +155,28 @@ All validation panic messages must use the prefix `wspulse:` followed by a space
 | #   | Option               | Field        | Condition    | Panic message                                                                         |
 | --- | -------------------- | ------------ | ------------ | ------------------------------------------------------------------------------------- |
 | 1   | `NewServer`          | `connect`    | `!= nil`     | `wspulse: NewServer: connect must not be nil`                                         |
-| 2   | `WithHeartbeat`      | `pingPeriod` | `> 0`        | `wspulse: WithHeartbeat: pingPeriod must be positive and strictly less than pongWait` |
-| 3   | `WithHeartbeat`      | `pongWait`   | `> 0`        | _(same as #2 — combined check)_                                                       |
-| 4   | `WithHeartbeat`      | `pingPeriod` | `< pongWait` | _(same as #2 — combined check)_                                                       |
-| 5   | `WithHeartbeat`      | `pingPeriod` | `<= 5 m`     | `wspulse: WithHeartbeat: pingPeriod exceeds maximum (5m)`                             |
-| 6   | `WithHeartbeat`      | `pongWait`   | `<= 10 m`    | `wspulse: WithHeartbeat: pongWait exceeds maximum (10m)`                              |
-| 7   | `WithWriteWait`      | `d`          | `> 0`        | `wspulse: WithWriteWait: duration must be positive`                                   |
-| 8   | `WithWriteWait`      | `d`          | `<= 30 s`    | `wspulse: WithWriteWait: duration exceeds maximum (30s)`                              |
-| 9   | `WithMaxMessageSize` | `n`          | `>= 1`       | `wspulse: WithMaxMessageSize: n must be at least 1`                                   |
-| 10  | `WithMaxMessageSize` | `n`          | `<= 64 MiB`  | `wspulse: WithMaxMessageSize: n exceeds maximum (64 MiB)`                             |
-| 11  | `WithSendBufferSize` | `n`          | `>= 1`       | `wspulse: WithSendBufferSize: n must be at least 1`                                   |
-| 12  | `WithSendBufferSize` | `n`          | `<= 4096`    | `wspulse: WithSendBufferSize: n exceeds maximum (4096)`                               |
-| 13  | `WithResumeWindow`   | `d`          | `>= 0`       | `wspulse: WithResumeWindow: duration must be non-negative`                            |
-| 14  | `WithCodec`          | `codec`      | `!= nil`     | `wspulse: WithCodec: codec must not be nil`                                           |
-| 15  | `WithCheckOrigin`    | `fn`         | `!= nil`     | `wspulse: WithCheckOrigin: fn must not be nil`                                        |
-| 16  | `WithLogger`         | `l`          | `!= nil`     | `wspulse: WithLogger: logger must not be nil`                                         |
+| 2   | `WithPingInterval`   | `d`          | `> 0`                    | `wspulse: WithPingInterval: duration must be positive`                                |
+| 3   | `WithPingInterval`   | `d`          | `<= 1 m`                | `wspulse: WithPingInterval: duration exceeds maximum (1m0s)`                          |
+| 4   | `WithWriteTimeout`   | `d`          | `> 0`                    | `wspulse: WithWriteTimeout: duration must be positive`                                |
+| 5   | `WithWriteTimeout`   | `d`          | `<= 30 s`               | `wspulse: WithWriteTimeout: duration exceeds maximum (30s)`                           |
+| 6   | `NewHub`             | cross        | `pingInterval > writeTimeout` | `wspulse: NewHub: pingInterval must be greater than writeTimeout`                |
+| 7   | `WithMaxMessageSize` | `n`          | `>= 1`                  | `wspulse: WithMaxMessageSize: n must be at least 1`                                   |
+| 8   | `WithMaxMessageSize` | `n`          | `<= 64 MiB`             | `wspulse: WithMaxMessageSize: n exceeds maximum (64 MiB)`                             |
+| 9   | `WithSendBufferSize` | `n`          | `>= 1`                  | `wspulse: WithSendBufferSize: n must be at least 1`                                   |
+| 10  | `WithSendBufferSize` | `n`          | `<= 4096`               | `wspulse: WithSendBufferSize: n exceeds maximum (4096)`                               |
+| 11  | `WithResumeWindow`   | `d`          | `>= 0`                  | `wspulse: WithResumeWindow: duration must be non-negative`                            |
+| 12  | `WithCodec`          | `codec`      | `!= nil`                | `wspulse: WithCodec: codec must not be nil`                                           |
+| 13  | `WithCheckOrigin`    | `fn`         | `!= nil`                | `wspulse: WithCheckOrigin: fn must not be nil`                                        |
+| 14  | `WithLogger`         | `l`          | `!= nil`                | `wspulse: WithLogger: logger must not be nil`                                         |
 
 Notes:
 
-- Rules #2–#4 are enforced by a single combined check in `WithHeartbeat`.
+- `WithPingInterval` and `WithWriteTimeout` are validated independently at option time; the cross-constraint (`pingInterval > writeTimeout`) is enforced by `NewHub` after all options are applied (rule 6).
 - `WithResumeWindow(0)` is valid — it disables session resumption (the default).
 - `maxMessageSize` minimum is 1 (unlike client where 0 disables the limit). The server always enforces a message size limit.
 - Callback options (`WithOnConnect`, `WithOnMessage`, `WithOnDisconnect`, `WithOnTransportDrop`, `WithOnTransportRestore`) accept `nil` — nil means no callback registered.
 - Upper bounds are intentionally conservative for a v0 library. They can be relaxed in future versions without breaking existing callers.
-- Boundary values (e.g. `sendBufferSize = 4096`, `writeWait = 30s`) are valid and must be accepted.
+- Boundary values (e.g. `sendBufferSize = 4096`, `writeTimeout = 30s`) are valid and must be accepted.
 
 ---
 

--- a/doc/contracts/server/test-scenarios.md
+++ b/doc/contracts/server/test-scenarios.md
@@ -47,7 +47,7 @@ Server integration tests use real WebSocket connections. The test harness create
 | Broadcast after Close                 | `Server.Broadcast` returns `ErrServerClosed`.                                               |
 | Send buffer full (direct Send)        | `Connection.Send` returns `ErrSendBufferFull` when buffer is at capacity.                   |
 | Broadcast backpressure (drop-oldest)  | Slow consumer's oldest frame is dropped; other consumers receive all frames.                |
-| Heartbeat timeout                     | Server closes connection after no Pong within `pongWait`. `OnDisconnect` fires.             |
+| Heartbeat timeout                     | Server closes connection after no Pong within `writeTimeout`. `OnDisconnect` fires.         |
 | OnMessage ordering                    | Frames sent by client arrive at `OnMessage` in order.                                       |
 | Resume buffer replay ordering         | Frames buffered during suspension are replayed in original order after reconnect.            |
 | GetConnections includes suspended     | `GetConnections` returns suspended sessions within the resume window.                       |

--- a/doc/contracts/server/test-scenarios.md
+++ b/doc/contracts/server/test-scenarios.md
@@ -13,7 +13,7 @@ For wire-level details see [`protocol.md`](https://github.com/wspulse/.github/bl
 
 ## Test Infrastructure
 
-Server integration tests use real WebSocket connections. The test harness creates a `wspulse.Server` instance, binds it to a local `httptest.Server`, and connects clients via `gorilla/websocket` (or `client-go`).
+Server integration tests use real WebSocket connections. The test harness creates a `wspulse.Server` instance, binds it to a local `httptest.Server`, and connects clients via `coder/websocket` (or `client-go`).
 
 ---
 
@@ -47,7 +47,7 @@ Server integration tests use real WebSocket connections. The test harness create
 | Broadcast after Close                 | `Server.Broadcast` returns `ErrServerClosed`.                                               |
 | Send buffer full (direct Send)        | `Connection.Send` returns `ErrSendBufferFull` when buffer is at capacity.                   |
 | Broadcast backpressure (drop-oldest)  | Slow consumer's oldest frame is dropped; other consumers receive all frames.                |
-| Heartbeat timeout                     | Server closes connection after no Pong within `writeTimeout`. `OnDisconnect` fires.         |
+| Heartbeat timeout                     | Server closes connection if no Pong is received within `writeTimeout` of sending a Ping. `OnDisconnect` fires. |
 | OnMessage ordering                    | Frames sent by client arrive at `OnMessage` in order.                                       |
 | Resume buffer replay ordering         | Frames buffered during suspension are replayed in original order after reconnect.            |
 | GetConnections includes suspended     | `GetConnections` returns suspended sessions within the resume window.                       |

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -93,7 +93,7 @@ The server sends a **Ping** every `pingInterval` (default 20 s). Clients
 auto-reply with a **Pong** at the protocol layer (browsers and other
 standard WebSocket libraries handle this automatically). The server's
 Ping call is synchronous — it sends a Ping and blocks until the Pong
-reply arrives or the `writeTimeout` (default 10 s) context expires. If
+reply arrives or the write deadline (`writeTimeout`, default 10 s) expires. If
 no Pong arrives within `writeTimeout`, the server closes the connection.
 The client detects this via a read error, which triggers a transport
 drop (and reconnect if enabled).

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -85,24 +85,16 @@ agnostic to the on-wire format (Protobuf, MessagePack, CBOR, etc.).
 
 ## Heartbeat
 
-wspulse uses a **dual heartbeat** model — both sides independently send
-WebSocket Ping control frames and monitor Pong replies.
+wspulse uses a **server-only heartbeat** model. The server sends WebSocket
+Ping control frames and monitors Pong replies to detect dead connections.
+Clients do not send their own Ping frames.
 
-**Server → Client:** The server sends a **Ping** every `pingPeriod`
-(default 10 s). Clients auto-reply with a **Pong** at the protocol layer
-(gorilla, browsers, and other standard WebSocket libraries handle this
-automatically). If the server receives no Pong within `pongWait`
-(default 30 s), it closes the connection.
-
-**Client → Server:** Native clients (Go, Node.js) **also** send their
-own **Ping** every `pingPeriod` (default 20 s). The server auto-replies
-with a **Pong** (gorilla default `PingHandler`). If the client receives
-no Pong within `pongWait` (default 60 s), it closes the socket and
-triggers a transport drop.
-
-> **Browser note:** The browser WebSocket API does not expose Ping/Pong
-> control frames. Browser clients rely entirely on the server-side
-> heartbeat for liveness detection.
+The server sends a **Ping** every `pingPeriod` (default 10 s). Clients
+auto-reply with a **Pong** at the protocol layer (gorilla, browsers, and
+other standard WebSocket libraries handle this automatically). If the
+server receives no Pong within `pongWait` (default 30 s), it closes the
+connection. The client detects this via a read error, which triggers a
+transport drop (and reconnect if enabled).
 
 ---
 
@@ -118,9 +110,6 @@ Client                           Server
   |                                |
   |<----------- Ping --------------|  (server pingPeriod, default 10 s)
   |------------ Pong ------------->|  (auto-reply)
-  |                                |
-  |------------ Ping ------------->|  (client pingPeriod, default 20 s)
-  |<----------- Pong --------------|  (auto-reply)
   |                                |
   |--------- Close frame --------->|  (normal close by client)
   |<-------- Close frame ----------|

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -89,12 +89,12 @@ wspulse uses a **server-only heartbeat** model. The server sends WebSocket
 Ping control frames and monitors Pong replies to detect dead connections.
 Clients do not send their own Ping frames.
 
-The server sends a **Ping** every `pingPeriod` (default 10 s). Clients
+The server sends a **Ping** every `pingInterval` (default 20 s). Clients
 auto-reply with a **Pong** at the protocol layer (gorilla, browsers, and
 other standard WebSocket libraries handle this automatically). If the
-server receives no Pong within `pongWait` (default 30 s), it closes the
-connection. The client detects this via a read error, which triggers a
-transport drop (and reconnect if enabled).
+server receives no Pong within `writeTimeout` (default 10 s), it closes
+the connection. The client detects this via a read error, which triggers
+a transport drop (and reconnect if enabled).
 
 ---
 
@@ -108,7 +108,7 @@ Client                           Server
   |                                |
   |     [frames exchanged]         |
   |                                |
-  |<----------- Ping --------------|  (server pingPeriod, default 10 s)
+  |<----------- Ping --------------|  (server pingInterval, default 20 s)
   |------------ Pong ------------->|  (auto-reply)
   |                                |
   |--------- Close frame --------->|  (normal close by client)

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -90,11 +90,13 @@ Ping control frames and monitors Pong replies to detect dead connections.
 Clients do not send their own Ping frames.
 
 The server sends a **Ping** every `pingInterval` (default 20 s). Clients
-auto-reply with a **Pong** at the protocol layer (gorilla, browsers, and
-other standard WebSocket libraries handle this automatically). If the
-server receives no Pong within `writeTimeout` (default 10 s), it closes
-the connection. The client detects this via a read error, which triggers
-a transport drop (and reconnect if enabled).
+auto-reply with a **Pong** at the protocol layer (browsers and other
+standard WebSocket libraries handle this automatically). The server's
+Ping call is synchronous — it sends a Ping and blocks until the Pong
+reply arrives or the `writeTimeout` (default 10 s) context expires. If
+no Pong arrives within `writeTimeout`, the server closes the connection.
+The client detects this via a read error, which triggers a transport
+drop (and reconnect if enabled).
 
 ---
 


### PR DESCRIPTION
## Summary

Remove client-side ping heartbeat from all contract and protocol documents, switching to a server-only heartbeat model. Part of wspulse/.github#39.

## Related issues

Relates to wspulse/.github#39

## Changes

- **interface.md**: removed `heartbeat` option row; removed validation rules 5–9 (pingPeriod/pongWait); renumbered rules 10–17 → 5–12
- **behaviour.md**: rewrote Heartbeat section from dual to server-only model; removed client-side heartbeat.
- **test-scenarios.md**: removed scenario  (heartbeat pong timeout); removed `?ignore_pings=1` query param; renumbered scenarios and threading note references; updated minimum test count 16 → 15
- **protocol.md**: rewrote Heartbeat section to server-only; removed Client→Server Ping/Pong lines from connection lifecycle diagram; removed browser note

## Checklist

### Required

- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] Documentation changes: verified accuracy against source repos